### PR TITLE
Added header file  iom644rfr2.h

### DIFF
--- a/avr-libc/include/avr/wdt.h
+++ b/avr-libc/include/avr/wdt.h
@@ -37,7 +37,7 @@
 
 #ifndef _AVR_WDT_H_
 #define _AVR_WDT_H_
-
+#include <iom644rfr2.h> // NOTE Add thsi import for header file to function properly.
 #include <avr/io.h>
 #include <stdint.h>
 


### PR DESCRIPTION
iom644rfr2.h contains some of the macros used in this file i.e., wdt.h